### PR TITLE
vol180 - need to #include <time.h> in some modules

### DIFF
--- a/Tools/linux/vol180/bitmap.c
+++ b/Tools/linux/vol180/bitmap.c
@@ -23,6 +23,7 @@
 #include <string.h>
 #include <errno.h>
 #include <stdlib.h>
+#include <time.h>
 
 #include "fileio.h"
 #include "buffer.h"

--- a/Tools/linux/vol180/check.c
+++ b/Tools/linux/vol180/check.c
@@ -24,6 +24,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <ctype.h>
+#include <time.h>
 
 #include "check.h"
 #include "indexf.h"

--- a/Tools/linux/vol180/mount.c
+++ b/Tools/linux/vol180/mount.c
@@ -23,6 +23,7 @@
 #include <string.h>
 #include <errno.h>
 #include <stdlib.h>
+#include <time.h>
 
 #include "buffer.h"
 #include "fileio.h"


### PR DESCRIPTION
Hector,  

Trying a build on macOS of vol180 I get diagnostics from the compiler.

The bitmap, check and mount modules #include fileio.h and have a reference to type time_t
which is undefined.  I added #include <time.h> to these.

Still getting a warning that I didn't yet fix because I'm not sure of the implications of increasing
the size of fname -

```
maxi:vol180 tony$ make
cc -g -Wall -c main.c
cc -g -Wall -c mount.c
cc -g -Wall -c dirio.c
dirio.c:96:3: warning: array index 13 is past the end of the array (which
      contains 13 elements) [-Warray-bounds]
  fname[13] = '\0';
  ^     ~~
dirio.c:87:3: note: array 'fname' declared here
  char fname[13], *ext, *pvers;
  ^
1 warning generated.
cc -g -Wall -c indexf.c
cc -g -Wall -c fileio.c
cc -g -Wall -c bitmap.c
cc -g -Wall -c buffer.c
cc -g -Wall -c blockio.c
cc -g -Wall -c mkdisk.c
cc -g -Wall -c vmr.c
cc -g -Wall -c misc.c
cc -g -o vol180 main.o mount.o dirio.o indexf.o fileio.o bitmap.o buffer.o blockio.o mkdisk.o vmr.o misc.o 
cc -g -Wall -c check.c
check.c:1026:65: warning: variable 'next' is uninitialized when used here
      [-Wuninitialized]
            printf("*** Could not read block %ld, aborting.\n", next);
                                                                ^~~~
check.c:997:27: note: initialize the variable 'next' to silence this warning
        unsigned long next;
                          ^
                           = 0
1 warning generated.
cc -g -o fsck180 check.o buffer.o blockio.o indexf.o fileio.o bitmap.o dirio.o misc.o 
```